### PR TITLE
Pass all options to gulp-iconfont

### DIFF
--- a/IconFontPlugin.js
+++ b/IconFontPlugin.js
@@ -20,12 +20,10 @@ function jsonDependency (objectFactory) {
 }
 
 function IconFontPlugin (options) {
-    options = options || {};
-    this.options = {
-        fontName: options.fontName || "myfont",
-        filenameTemplate: options.filenameTemplate || {
-            name: "[name]-[hash].[ext]",
-        },
+    this.options = options || {};
+    this.options.fontName =  options.fontName || "myfont";
+    this.options.filenameTemplate = options.filenameTemplate || {
+        name: "[name]-[hash].[ext]",
     };
 
     this.codepoints = [];

--- a/IconFontPlugin.js
+++ b/IconFontPlugin.js
@@ -87,6 +87,9 @@ IconFontPlugin.prototype.apply = function (compiler) {
                     return module.rawRequest === "iconfont-loader";
                 })[0];
 
+                global.FONTICONPLUGIN_CODEPOINTS = plugin.codepoints;
+                global.FONTICONPLUGIN_STYLES = plugin.styles;
+
                 compilation.rebuildModule(module, callback);
             });
 


### PR DESCRIPTION
Hello,

I needed to pass some options to `gulp-iconfont`, but the options were not forwarded to the module. I've fixed the plugin initialization to make it work.
